### PR TITLE
[feat] 기업 비교 페이지 추가 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "package",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2"
@@ -1622,6 +1623,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1636,6 +1643,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1712,7 +1730,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1806,6 +1823,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1967,6 +1996,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1984,7 +2022,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2075,7 +2112,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2085,7 +2121,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2123,7 +2158,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2136,7 +2170,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2561,6 +2594,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2575,6 +2628,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -2596,7 +2665,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2647,7 +2715,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2672,7 +2739,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2747,7 +2813,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2812,7 +2877,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2825,7 +2889,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -2841,7 +2904,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3472,10 +3534,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3843,6 +3925,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2"

--- a/src/api/compare.js
+++ b/src/api/compare.js
@@ -1,0 +1,31 @@
+import instance from "@/lib/axios";
+
+/**
+ * 전체 비교 기업 목록 조회
+ * @param {object} params - 페이지네이션, 정렬 정보
+ * 예: { page: 1, limit: 10 }
+ */
+export const getCorpList = (params) => instance.get("/compare", { params });
+
+/**
+ * 특정 기업 비교 선택 & 옵션 카운트
+ * @param {string|number} id - 기업 ID
+ * @param {object} payload - 옵션 데이터 (예: { option: "A" })
+ */
+export const postMyCorp = (id, payload) =>
+  instance.post(`/compare/mycorpinfo/${id}`, payload);
+
+/**
+ * 나의 기업 비교 선택 & 옵션 카운트
+ * @param {string|number} id - 기업 ID
+ * @param {object} payload - 옵션 데이터 (예: { option: "A" })
+ */
+export const postCompareCorp = (id, payload) =>
+  instance.post(`/compare/corpinfo/${id}`, payload);
+
+/**
+ * 비교 결과 목록 조회
+ * @param {object} params - 페이지네이션, 정렬 정보
+ * 예: { sort: "asc" }
+ */
+export const getCompareList = (params) => instance.get("/compare", { params });

--- a/src/api/compare.js
+++ b/src/api/compare.js
@@ -1,11 +1,19 @@
 import instance from "@/lib/axios";
 
 /**
- * 전체 비교 기업 목록 조회
+ * 내 기업 선택 모달 전체 기업 목록 조회
  * @param {object} params - 페이지네이션, 정렬 정보
  * 예: { page: 1, limit: 10 }
  */
-export const getCorpList = (params) => instance.get("/compare", { params });
+export const getMyCorpList = (params) => instance.get("/compare", { params });
+
+/**
+ * 내 기업 선택 모달 전체 기업 목록 조회
+ * @param {object} params - 페이지네이션, 정렬 정보
+ * 예: { page: 1, limit: 10 }
+ */
+export const getCompareCorpList = (id, params) =>
+  instance.get(`/compare/${id}`, { params });
 
 /**
  * 특정 기업 비교 선택 & 옵션 카운트

--- a/src/api/compare.js
+++ b/src/api/compare.js
@@ -36,4 +36,16 @@ export const postCompareCorp = (id, payload) =>
  * @param {object} params - 페이지네이션, 정렬 정보
  * 예: { sort: "asc" }
  */
-export const getCompareList = (params) => instance.get("/compare", { params });
+export const getCompareList = (params) =>
+  instance.get("/compare/comparerank", { params });
+
+/*
+// 기업 비교 현황  랭킹 추가해서 조회
+GET http://localhost:3000/compare/comparerank
+
+// 기업 비교 현황 랭킹없이 조회
+GET http://localhost:3000/compare/compareorder
+
+// 기업 비교 현황 그냥 합산해서 조회
+GET http://localhost:3000/compare/comparetotal
+*/

--- a/src/api/invest.js
+++ b/src/api/invest.js
@@ -1,0 +1,17 @@
+import instance from "@/lib/axios";
+
+/**
+ * 나의 기업 투자하기
+ * @param {string|number} id - 기업 ID
+ * @param {object} payload - 옵션 데이터 (예: { option: "A" })
+ */
+export const postMyCorp = (id, payload) =>
+  instance.post(`/investment/corp/${id}`, payload);
+
+/**
+ * 기업 투자 수정하기
+ * @param {string|number} id - 기업 ID
+ * @param {object} payload - 옵션 데이터 (예: { option: "A" })
+ */
+export const patchMyCorp = (id, payload) =>
+  instance.patch(`/investment/corp/${id}`, payload);

--- a/src/components/CardContainer/CardAdded.jsx
+++ b/src/components/CardContainer/CardAdded.jsx
@@ -1,11 +1,11 @@
 import MinusIcon from "../../assets/minusIcon.svg";
 
-function CardAdded({ companyLogo, companyName, companyCategory }) {
+function CardAdded({ companyLogo, companyName, companyCategory, onRemove }) {
   return (
     <div className="card-added">
-      <div className="minus-icon">
+      <button className="minus-icon" onClick={onRemove}>
         <img src={MinusIcon} />
-      </div>
+      </button>
       <div className="card-inner">
         <img
           src={companyLogo}

--- a/src/components/CardContainer/index.jsx
+++ b/src/components/CardContainer/index.jsx
@@ -20,6 +20,7 @@ function CardContainer({
   setMyCompany,
   setCompareCompanies,
   //isData = false,
+  myCompanyId,
 }) {
   const [isMyModalOpen, setIsMyModalOpen] = useState(null);
   const [isCompareModalOpen, setIsCompareModalOpen] = useState(null);
@@ -117,6 +118,7 @@ function CardContainer({
             title="비교할 기업 선택하기"
             initialSelection={companyList} // 이전에 선택한 목록을 전달
             onConfirm={onSelectCompare} // 모달이 닫힐 때 선택 결과를 부모로 전달
+            id={myCompanyId}
           />
         )}
       </div>

--- a/src/components/CardContainer/index.jsx
+++ b/src/components/CardContainer/index.jsx
@@ -16,6 +16,9 @@ function CardContainer({
   onSelectCompany, // ComparePage로부터 받을 기업 선택 함수
   onSelectCompare, // ComparePage로부터 받을 비교 기업 선택 함수
   companyList, // ComparePage로부터 받을 비교 기업들 정보
+  onRemove, // ComparePage로부터 받을 카드 제거 함수
+  setMyCompany,
+  setCompareCompanies,
   //isData = false,
 }) {
   const [isMyModalOpen, setIsMyModalOpen] = useState(null);
@@ -27,9 +30,13 @@ function CardContainer({
     setIsCompareModalOpen(true);
   };
 
-  // title에 따라 어떤 모달을 열지 결정합니다.
+  // 나의 기업 컨테이너면 상태 초기화 비교 기업 컨테이너면 모달 open
   const handleButtonClick = title.includes("나의 기업")
-    ? openMyCompanyModal
+    ? () => {
+      setMyCompany(null);
+      setCompareCompanies([]);
+      openMyCompanyModal();
+    } 
     : openCompareCompanyModal;
 
   const handleSelectMyCompanyAndClose = (company) => {
@@ -49,7 +56,8 @@ function CardContainer({
           <div className="title">{title}</div>
           <div className="desc">{desc}</div>
         </div>
-        <LargeButton onClick={handleButtonClick}>{btnName}</LargeButton>
+        {btnName !== '' ? <LargeButton onClick={handleButtonClick}>{btnName}</LargeButton> : <></> }
+        
       </div>
       <div className="card-main">
         {(() => {
@@ -62,6 +70,7 @@ function CardContainer({
                   companyLogo={selectedCompany.logoUrl}
                   companyName={selectedCompany.name}
                   companyCategory={selectedCompany.category}
+                  onRemove={onRemove} // 나의 기업 카드 제거 함수
                 />
               );
             }
@@ -80,6 +89,7 @@ function CardContainer({
                 companyLogo={el.logoUrl}
                 companyName={el.name}
                 companyCategory={el.category}
+                onRemove={() => onRemove(el.id)} // 비교 기업 카드 제거 함수
               />
             ));
           }

--- a/src/components/modals/CompareCompanyModal.jsx
+++ b/src/components/modals/CompareCompanyModal.jsx
@@ -97,7 +97,8 @@ export default function CompareCompanyModal({
     return () => {
       onConfirm(selectedList);
     };
-  }, [selectedList, onConfirm]); // 여기 onConfirm은 왜 넣어?
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedList]); // onConfirm은 부모에서 useCallback으로 메모이제이션 되었으므로 의존성에서 제거해도 안전합니다. // FIXME: 왜 onConfirm하면 무한 렌더링이 됐는지 궁금
 
   // 렌더링할 목록: 검색어가 있으면 필터링된 결과를, 없으면 전체 데이터를 사용
   const listToRender = keyword.trim() ? filteredData : data;

--- a/src/components/modals/CompareCompanyModal.jsx
+++ b/src/components/modals/CompareCompanyModal.jsx
@@ -81,13 +81,19 @@ export default function CompareCompanyModal({
     setSelectedList((prev) => prev.filter((item) => item.id !== id));
   };
 
+  const tempId = "11111111-aaaa-bbbb-cccc-000000000003";
+
   useEffect(() => {
-    getCompareCorpList(id, {
-      // 예: page=1 -> offset=0
-      offset: (page - 1) * limit,
-      limit,
-      // order,
-    }).then((res) => {
+    getCompareCorpList(
+      //id
+      tempId,
+      {
+        // 예: page=1 -> offset=0
+        offset: (page - 1) * limit,
+        limit: 5,
+        // order,
+      }
+    ).then((res) => {
       setData(res.data);
       setTotal(res.totalCount);
     });
@@ -106,7 +112,7 @@ export default function CompareCompanyModal({
   const listToRender = keyword.trim() ? filteredData : data;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={title}> 
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
       <div className="modal-body">
         <div className="modal-padding">
           <SearchBar

--- a/src/components/modals/CompareCompanyModal.jsx
+++ b/src/components/modals/CompareCompanyModal.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Modal from "@/components/modals/Modal";
 import SearchBar from "@/components/SearchBar";
-import { fetchCorpData } from "@/api/MockPaginationApi";
+// import { fetchCorpData } from "@/api/MockPaginationApi";
 import Pagination from "@/components/Pagination";
 import "../../components/modals/Modal.css";
 import CompanySelectRow from "../CompanySelectRow";
+import { getCompareCorpList } from "@/api/compare";
 
 export default function CompareCompanyModal({
   isOpen,
@@ -12,6 +13,7 @@ export default function CompareCompanyModal({
   title,
   initialSelection = [],
   onConfirm, // 부모로부터 받을 콜백 함수
+  id,
 }) {
   const [keyword, setKeyword] = useState("");
 
@@ -80,7 +82,7 @@ export default function CompareCompanyModal({
   };
 
   useEffect(() => {
-    fetchCorpData({
+    getCompareCorpList(id, {
       // 예: page=1 -> offset=0
       offset: (page - 1) * limit,
       limit,
@@ -105,7 +107,6 @@ export default function CompareCompanyModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={title}> 
-    {/* ㄴㄴ 이 모달은 버튼이 없어야하는 모달임. 그래서 모달이 꺼질때 selectedList가 compareCompanies 같은데에 저장? 반환? 되어야함 */}
       <div className="modal-body">
         <div className="modal-padding">
           <SearchBar

--- a/src/components/modals/InvestmentModal.jsx
+++ b/src/components/modals/InvestmentModal.jsx
@@ -1,13 +1,26 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import LabelInput from "@/components/LabelInput";
 import Modal from "./Modal";
+import OneButtonPopup from "./OneButtonPopup";
+import { postMyCorp, patchMyCorp } from "@/api/invest";
 
-function InvestmentModal({ isOpen, company, onClose }) {
-  const [investor, setInvestor] = useState("");
-  const [amount, setAmount] = useState("");
-  const [comment, setComment] = useState("");
+function InvestmentModal({ isOpen, company, onClose, initialData }) {
+  const isEditMode = !!initialData; // 수정 모달이니?
+
+  const [investor, setInvestor] = useState(initialData?.investor || "");
+  const [amount, setAmount] = useState(initialData?.amount || "");
+  const [comment, setComment] = useState(initialData?.comment || "");
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
+
+  // initialData가 변경되면 상태를 다시 초기화합니다. // FIXME: 이거 굳이 필요?
+  useEffect(() => {
+    if (initialData) {
+      setInvestor(initialData.investor || "");
+      setAmount(initialData.amount || "");
+      setComment(initialData.comment || "");
+    }
+  }, [initialData]);
 
   // 비밀번호 일치 여부 확인
   const isPasswordMatching = password === passwordConfirm;
@@ -24,76 +37,112 @@ function InvestmentModal({ isOpen, company, onClose }) {
     passwordConfirm.trim() !== "" &&
     isPasswordMatching;
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   // company prop이 없으면 렌더링하지 않거나, 기본값을 설정할 수 있습니다.
   if (!company) return null;
 
+  /** 투자 요청을 제출하는 함수 */
+  const handleInvestSubmit = async () => {
+    const payload = {
+      investor,
+      amount: Number(amount),
+      comment,
+      password,
+    };
+
+    try {
+      if (isEditMode) {
+        await patchMyCorp(initialData.id, payload); // 수정 API 호출
+      } else {
+        await postMyCorp(company.id, payload); // 생성 API 호출
+      }
+      setIsModalOpen(true); // 성공 시에만 팝업을 띄웁니다.
+    } catch (error) {
+      console.error(`투자 ${isEditMode ? "수정" : "하기"} 실패:`, error);
+      // 필요하다면 여기에 에러 팝업을 띄우는 로직을 추가할 수 있습니다.
+    }
+  };
+
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      title="기업에 투자하기"
-      footer={{
-        cancelText: "취소",
-        confirmText: "투자하기",
-        onConfirm: () => {
-          console.log("투자 실행");
-          onClose(); // FIXME: 추후 1button 알림 가능 추가
-        }, // 실제 투자 로직 연결
-        isConfirmDisabled: !isFormValid,
-      }}
-    >
-      <div className="invest-info">
-        <div className="invest-label">투자 기업 정보</div>
-        <div className="company-info">
-          <div
-            className="company-logo"
-            role="img"
-            aria-label={`${company.name} 로고`}
-            style={{
-              backgroundImage: company.logoUrl
-                ? `url(${company.logoUrl})`
-                : "none",
-            }}
-          />
-          <div className="company-name">{company.name}</div>
-          <div className="company-category">{company.category}</div>
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        title="기업에 투자하기"
+        footer={{
+          cancelText: "취소",
+          confirmText: isEditMode ? "수정하기" : "투자하기",
+          onConfirm: handleInvestSubmit,
+          isConfirmDisabled: !isFormValid,
+        }}
+      >
+        <div className="invest-info">
+          <div className="invest-label">투자 기업 정보</div>
+          <div className="company-info">
+            <div
+              className="company-logo"
+              role="img"
+              aria-label={`${company.name} 로고`}
+              style={{
+                backgroundImage: company.logoUrl
+                  ? `url(${company.logoUrl})`
+                  : "none",
+              }}
+            />
+            <div className="company-name modal-company-name">
+              {company.name}
+            </div>
+            <div className="company-category">{company.category}</div>
+          </div>
         </div>
-      </div>
-      <LabelInput
-        label="투자자 이름"
-        value={investor}
-        onChange={setInvestor}
-        required
-      />
-      <LabelInput
-        label="투자 금액"
-        type="number"
-        value={amount}
-        onChange={setAmount}
-        required
-      />
-      <LabelInput
-        label="투자 코멘트"
-        value={comment}
-        onChange={setComment}
-        multiline
-      />
-      <LabelInput
-        label="비밀번호"
-        type="password"
-        value={password}
-        onChange={setPassword}
-        required
-      />
-      <LabelInput
-        label="비밀번호 확인"
-        type="password"
-        value={passwordConfirm}
-        onChange={setPasswordConfirm}
-        error={passwordError}
-        required
-      />
-    </Modal>
+        <LabelInput
+          label="투자자 이름"
+          value={investor}
+          onChange={setInvestor}
+          required
+        />
+        <LabelInput
+          label="투자 금액"
+          type="number"
+          value={amount}
+          onChange={setAmount}
+          required
+        />
+        <LabelInput
+          label="투자 코멘트"
+          value={comment}
+          onChange={setComment}
+          multiline
+        />
+        <LabelInput
+          label="비밀번호"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          required
+        />
+        <LabelInput
+          label="비밀번호 확인"
+          type="password"
+          value={passwordConfirm}
+          onChange={setPasswordConfirm}
+          error={passwordError}
+          required
+        />
+      </Modal>
+      {isModalOpen && (
+        <OneButtonPopup
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          message={`투자가 ${isEditMode ? "수정" : "완료"}되었어요!`}
+          onButtonClick={() => {
+            setIsModalOpen(false);
+            onClose();
+          }}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/components/modals/Modal.css
+++ b/src/components/modals/Modal.css
@@ -109,8 +109,11 @@
   font-size: 18px;
   font-weight: 500;
   line-height: normal;
-
   padding: 0 8px 0 12px;
+}
+
+.company-name.modal-company-name {
+  font-size: 20px;
 }
 
 .company-category {
@@ -162,9 +165,10 @@
   padding-top: 6px;
   padding-bottom: 8px;
 }
-.modal-body {
+
+/* .modal-body {
   padding: 24px;
-}
+} */
 
 .form-field {
   display: flex;

--- a/src/components/modals/MyCompanyModal.jsx
+++ b/src/components/modals/MyCompanyModal.jsx
@@ -79,10 +79,12 @@ export default function MyCompanyModal({
     getMyCorpList({
       // 예: page=1 -> offset=0
       offset: (page - 1) * limit,
-      limit,
+      limit: limit,
+      order: "investment_desc",
     }).then((res) => {
-      setData(res.data);
-      setTotal(res.totalCount);
+      // 백엔드에서 { data: [...], totalCount: ... } 형식으로 응답한다고 가정합니다.
+      setData(res.data.data);
+      setTotal(res.data.totalCount);
     });
   }, [page]);
 

--- a/src/components/modals/MyCompanyModal.jsx
+++ b/src/components/modals/MyCompanyModal.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Modal from "@/components/modals/Modal";
 import SearchBar from "@/components/SearchBar";
-import { fetchCorpData, fetchInvestedCompanies } from "@/api/MockPaginationApi";
+// import { fetchCorpData, fetchInvestedCompanies } from "@/api/MockPaginationApi";
 import Pagination from "@/components/Pagination";
 import "../../components/modals/Modal.css";
 import CompanySelectRow from "../CompanySelectRow";
+import { getMyCorpList } from "@/api/compare";
 
 const RECENT_SELECTIONS_KEY = "recentMyCompanySelections"; // 오잉 이건 왜?
 const MAX_RECENT_SELECTIONS = 5; // 이건 왜?
@@ -48,10 +49,11 @@ export default function MyCompanyModal({
         // 캐시가 있으면?
         setRecentSelections(JSON.parse(stored));
       }
-      // 2. 내가 투자한 기업 목록 불러오기 (API 호출)
-      fetchInvestedCompanies().then((res) => {
-        setInvestedCompanies(res.data);
-      });
+      // // 2. 내가 투자한 기업 목록 불러오기 (API 호출)
+      // fetchInvestedCompanies().then((res) => {
+      //   setInvestedCompanies(res.data);
+      // });
+      // FIXME: 내가 투자한 데이터? 최근 투자한 데이터? API 호출
     }
   }, [isOpen]);
 
@@ -74,7 +76,7 @@ export default function MyCompanyModal({
   };
 
   useEffect(() => {
-    fetchCorpData({
+    getMyCorpList({
       // 예: page=1 -> offset=0
       offset: (page - 1) * limit,
       limit,

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -1,0 +1,41 @@
+import axios from "axios";
+
+// 1. Axios 인스턴스 생성
+const instance = axios.create({
+  // 2. 기본 URL 설정
+  // 모든 요청에 `baseURL`이 앞에 붙게 됩니다.
+  // 예: '/users'로 요청하면 'https://api.example.com/users'로 요청됩니다.
+  // .env 파일 등을 통해 환경 변수로 관리하는 것이 좋습니다.
+  baseURL: "https://eight-viewmystartup-4-be.onrender.com",
+
+  // 3. 타임아웃 설정 (ms)
+  // 요청이 5초 이상 걸리면 에러 처리됩니다.
+  timeout: 5000,
+
+  // 4. 기본 헤더 설정
+  // 모든 요청에 기본으로 포함될 헤더입니다.
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true, // 필요 시 쿠키 전송
+});
+
+// 5. 요청 인터셉터 (Request Interceptor)
+// 요청을 보내기 전에 수행할 작업을 설정할 수 있습니다.
+instance.interceptors.request.use(
+  (config) => {
+    // 예: 로컬 스토리지에서 토큰을 가져와 헤더에 추가
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      config.headers["Authorization"] = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (res) => res,
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 6. 생성한 인스턴스를 내보냅니다.
+export default instance;

--- a/src/pages/ComparePage/ComparePage.css
+++ b/src/pages/ComparePage/ComparePage.css
@@ -5,6 +5,7 @@ body {
 .compare-page {
   display: flex;
   flex-direction: column;
+  margin-bottom: 80px;
 }
 
 .compare-page > :first-child {
@@ -19,16 +20,23 @@ body {
 .btn-center {
   display: flex;
   justify-content: center;
-  margin: 20px auto;
+  margin-top: 40px;
 }
 
-/* 테이블 섹션 */
+/* 결과 섹션 */
+
+.result-section {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  margin-top: 40px;
+}
 
 .table-section {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin: 10px auto;
+  /* margin: 10px auto; */
 }
 
 .saction-header {
@@ -128,4 +136,8 @@ body {
   color: #fff;
   font-size: 14px;
   font-weight: 500;
+}
+
+.corp-intro {
+  text-align: left;
 }

--- a/src/pages/ComparePage/index.jsx
+++ b/src/pages/ComparePage/index.jsx
@@ -69,9 +69,9 @@ export default function ComparePage() {
       alert("비교할 기업을 1개 이상 선택해주세요!");
       return;
     }
-    setComparisonList([myCompany, ...compareCompanies]);
-    setShowCompareButton(false);
-    /*
+    // setComparisonList([myCompany, ...compareCompanies]);
+    // setShowCompareButton(false);
+
     try {
       // 1. 나의 기업 POST
       await postMyCorp(myCompany.id, { option: "A" }); // FIXME: 뭘 보내야할지 차차..!
@@ -94,7 +94,7 @@ export default function ComparePage() {
       console.error("기업 비교 API 호출 중 오류: ", error);
       alert("기업 비교 중 오류가 발생하였습니다.");
     }
-      */
+      
   };
 
   // --- 메모이제이션을 통한 성능 최적화 ---
@@ -227,7 +227,7 @@ export default function ComparePage() {
         onSelectCompare={handleConfirmCompare}
         onRemove={handleRemoveCompareCompany}
         isData={compareCompanies.length > 0} // 비교 기업 목록 데이터 여부
-        myCompanyId={myCompany.id}
+        myCompanyId={myCompany?.id}
       />
 
       {/* 1. 나의 기업, 비교할 기업 둘 다 있을 때만 active, 

--- a/src/pages/ComparePage/index.jsx
+++ b/src/pages/ComparePage/index.jsx
@@ -227,6 +227,7 @@ export default function ComparePage() {
         onSelectCompare={handleConfirmCompare}
         onRemove={handleRemoveCompareCompany}
         isData={compareCompanies.length > 0} // 비교 기업 목록 데이터 여부
+        myCompanyId={myCompany.id}
       />
 
       {/* 1. 나의 기업, 비교할 기업 둘 다 있을 때만 active, 

--- a/src/pages/ComparePage/index.jsx
+++ b/src/pages/ComparePage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import CardContainer from "../../components/CardContainer";
 import LargeButton from "@/components/LargeButton";
 import "./ComparePage.css";
@@ -6,6 +6,7 @@ import Pagination from "@/components/Pagination";
 import { fetchCorpData } from "@/api/MockPaginationApi";
 import Dropdown from "@/components/Dropdown";
 import InvestmentModal from "@/components/modals/InvestmentModal";
+import { getCompareList, postMyCorp, postCompareCorp } from "@/api/compare";
 
 export default function ComparePage() {
   // --- 상태 관리 --- //
@@ -23,6 +24,9 @@ export default function ComparePage() {
   const [comparisonList, setComparisonList] = useState([]);
 
   const [isModalOpen, setIsModalOpen] = useState(false); // '기업에 투자하기' 모달 상태
+
+  // "기업 비교하기" 버튼 표시 상태
+  const [showCompareButton, setShowCompareButton] = useState(true);
 
   const orderOptions = [
     { value: "investmentHighest", label: "투자금 많은 순" },
@@ -46,10 +50,16 @@ export default function ComparePage() {
     });
   }, [rankOrder]); // '기업 순위' 테이블의 정렬 순서가 바뀌면 API를 다시 호출. rankedComparisonList에서 순위 매기는데 사용하기 때문에 useEffect에 rankOrder는 꼭 필요함
 
+  // 나의 기업 또는 비교 기업 목록이 변경되면, 비교 버튼을 다시 표시하고 이전 비교 결과를 초기화 FIXME: 흠 내 기업 카드 변경이 아니면 테이블을 그대로 둘지.. 고민
+  useEffect(() => {
+    setShowCompareButton(true);
+    setComparisonList([]);
+  }, [myCompany, compareCompanies]);
+
   // --- 이벤트 핸들러 ---
 
   // "기업 비교하기" 버튼 클릭 시, 선택된 기업들로 최종 비교 목록을 설정
-  const handleCompareClick = () => {
+  const handleCompareClick = async () => {
     // CardContainer에서 선택된 '나의 기업' 정보를 모달에 전달할 데이터로 설정
     if (!myCompany) {
       alert("먼저 '나의 기업'을 선택해주세요!");
@@ -59,11 +69,67 @@ export default function ComparePage() {
       alert("비교할 기업을 1개 이상 선택해주세요!");
       return;
     }
-    // myCompany와 compareCompanies를 합쳐서 최종 비교 목록 상태를 업데이트
     setComparisonList([myCompany, ...compareCompanies]);
+    setShowCompareButton(false);
+    /*
+    try {
+      // 1. 나의 기업 POST
+      await postMyCorp(myCompany.id, { option: "A" }); // FIXME: 뭘 보내야할지 차차..!
+
+      // 2. 비교할 기업 POST
+      await Promise.all(
+        compareCompanies
+          .slice(0, 5)
+          .map((corp) => postCompareCorp(corp.id, { option: "A" }))
+      );
+
+      // 3. 비교결과 GET
+      const response = await getCompareList({ sort: "inbestmentHighest" }); // FIXME: 나중에 dropdown이랑 상태 동기화
+      const compareData = response.data;
+
+      // 4. 화면에 반영
+      setComparisonList(compareData);
+      setShowCompareButton(false); // 비교 후 버튼 숨기기
+    } catch (error) {
+      console.error("기업 비교 API 호출 중 오류: ", error);
+      alert("기업 비교 중 오류가 발생하였습니다.");
+    }
+      */
   };
 
   // --- 메모이제이션을 통한 성능 최적화 ---
+
+  // '비교 결과 확인하기' 테이블을 위한 데이터 정렬 로직
+  // `useMemo`를 사용하여 `comparisonList`나 `compareOrder`가 변경될 때만 정렬을 다시 수행
+  const sortedComparisonList = useMemo(() => {
+    // 문자열에서 숫자만 추출하여 정수로 변환하는 함수
+    // 예: "1,000,000원" -> 1000000
+    const parseValue = (str) =>
+      parseInt(String(str).replace(/[^0-9]/g, ""), 10) || 0;
+
+    // `comparisonList`를 `compareOrder` 상태에 따라 정렬
+    // 원본 배열을 변경하지 않기 위해 `[...comparisonList]`로 복사본을 만들어 정렬
+    // 이 정렬 로직은 '비교 결과' 테이블에만 적용
+    const sorted = [...comparisonList].sort((a, b) => {
+      switch (compareOrder) {
+        case "investmentLowest":
+          return parseValue(a.investment) - parseValue(b.investment);
+        case "investmentHighest":
+          return parseValue(b.investment) - parseValue(a.investment);
+        case "salesLowest":
+          return parseValue(a.revenue) - parseValue(b.revenue);
+        case "salesHighest":
+          return parseValue(b.revenue) - parseValue(a.revenue);
+        case "employeeLowest":
+          return parseValue(a.employees) - parseValue(b.employees);
+        case "employeeHighest":
+          return parseValue(b.employees) - parseValue(a.employees);
+        default:
+          return 0;
+      }
+    });
+    return sorted;
+  }, [comparisonList, compareOrder]); // FIXME: 엥 아맞다 이것도 아래 Ranked랑 같은 데이터 뿌려주면 필요없어질듯?
 
   // `comparisonList`에 있는 각 기업의 순위 재계산
   // `useMemo`를 사용하여 `comparisonList`나 `data`가 변경될 때만 순위 재계산
@@ -108,59 +174,50 @@ export default function ComparePage() {
       });
   }, [comparisonList, data, rankOrder]);
 
-  // '비교 결과 확인하기' 테이블을 위한 데이터 정렬 로직
-  // `useMemo`를 사용하여 `comparisonList`나 `compareOrder`가 변경될 때만 정렬을 다시 수행
-  const sortedComparisonList = useMemo(() => {
-    // 문자열에서 숫자만 추출하여 정수로 변환하는 함수
-    // 예: "1,000,000원" -> 1000000
-    const parseValue = (str) =>
-      parseInt(String(str).replace(/[^0-9]/g, ""), 10) || 0;
-
-    // `comparisonList`를 `compareOrder` 상태에 따라 정렬
-    // 원본 배열을 변경하지 않기 위해 `[...comparisonList]`로 복사본을 만들어 정렬
-    // 이 정렬 로직은 '비교 결과' 테이블에만 적용
-    const sorted = [...comparisonList].sort((a, b) => {
-      switch (compareOrder) {
-        case "investmentLowest":
-          return parseValue(a.investment) - parseValue(b.investment);
-        case "investmentHighest":
-          return parseValue(b.investment) - parseValue(a.investment);
-        case "salesLowest":
-          return parseValue(a.revenue) - parseValue(b.revenue);
-        case "salesHighest":
-          return parseValue(b.revenue) - parseValue(a.revenue);
-        case "employeeLowest":
-          return parseValue(a.employees) - parseValue(b.employees);
-        case "employeeHighest":
-          return parseValue(b.employees) - parseValue(a.employees);
-        default:
-          return 0;
-      }
-    });
-    return sorted;
-  }, [comparisonList, compareOrder]);
-
   // `rankOrder`는 API 호출 시 사용되어 `data`를 결정하고, `data`는 `rankedComparisonList`에서 순위를 매길 때 사용
   // `compareOrder`는 사용자가 선택한 `comparisonList`를 클라이언트 측에서 정렬할 때 사용
-  // FIXME: 아니 근데 '기업 순위' 테이블에도 정렬 Dropdown에 따라 순위 뿐만 아니라 테이블 row도 정렬 되어야 함
 
-  // 1. MyCompanyModal에서 기업 선택 시 상태 업데이트
-  const handleSelectMyCompany = (company) => setMyCompany(company);
+  // MyCompanyModal에서 기업 선택 시 상태를 업데이트하는 함수입니다.
+  // `useCallback`은 의존성 배열([])이 비어있으므로, 컴포넌트가 처음 렌더링될 때 한 번만 함수를 생성합니다.
+  // 이후 리렌더링이 발생해도 함수를 재생성하지 않아 자식 컴포넌트(CardContainer)에 항상 동일한 참조의 함수를 전달하여 불필요한 리렌더링을 방지합니다.
+  const handleSelectMyCompany = useCallback((company) => {
+    setMyCompany(company);
+  }, []);
 
-  // 2. CompareCompanyModal에서 '선택 완료' 시 호출될 함수
-  const handleConfirmCompare = (companies) => {
+  // CompareCompanyModal에서 '선택 완료'(모달 닫기) 시 호출될 함수입니다.
+  // `useCallback`을 사용하지 않으면 ComparePage가 리렌더링될 때마다 이 함수도 새로 생성됩니다.
+  // 이 새로운 함수가 CompareCompanyModal의 prop으로 전달되면, 모달의 useEffect가 의존성(onConfirm) 변경으로 인해 불필요하게 실행되어 무한 렌더링을 유발할 수 있습니다.
+  // `useCallback`으로 함수 생성을 최적화하여 이 문제를 해결합니다.
+  const handleConfirmCompare = useCallback((companies) => {
     setCompareCompanies(companies);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // };
+  }, []);
+
+  // 나의 기업 카드에서 (-) 버튼 클릭 시
+  const handleRemoveMyCompany = () => {
+    setMyCompany(null);
+    setCompareCompanies([]);
+  };
+
+  // 비교할 기업 카드에서 (-) 버튼 클릭 시
+  const handleRemoveCompareCompany = (companyId) => {
+    setCompareCompanies((prev) =>
+      prev.filter((company) => company.id !== companyId)
+    );
   };
 
   return (
     <div className="compare-page">
       <CardContainer
         title={"나의 기업을 선택해주세요!"}
-        btnName={"기업 변경하기"} // 또는 "기업 변경하기"
+        btnName={myCompany ? "다른 기업 비교하기" : ""}
         // 선택된 기업 정보와 선택/초기화 함수를 props로 전달
         selectedCompany={myCompany}
         onSelectCompany={handleSelectMyCompany}
-        // onClear={() => setMyCompany(null)} FIXME: 오 맞아 minusIcon 버튼 누르면 cardAdded 없애야해
+        onRemove={handleRemoveMyCompany}
+        setMyCompany={setMyCompany}
+        setCompareCompanies={setCompareCompanies}
       />
       <CardContainer
         title={"어떤 기업이 궁금하세요?"}
@@ -168,130 +225,147 @@ export default function ComparePage() {
         btnName={"기업 추가하기"}
         companyList={compareCompanies}
         onSelectCompare={handleConfirmCompare}
+        onRemove={handleRemoveCompareCompany}
         isData={compareCompanies.length > 0} // 비교 기업 목록 데이터 여부
       />
 
-      {/* 비교할 기업 목록이 있을 때만 '기업 비교하기' 버튼 표시 */}
-      {myCompany && compareCompanies.length > 0 && (
+      {/* 1. 나의 기업, 비교할 기업 둘 다 있을 때만 active, 
+          2. 클릭 시 disappear,
+          3. 나의 기업, 비교할 기업 변경 시 appear */}
+      {showCompareButton && (
         <div className="btn-center">
-          <LargeButton onClick={handleCompareClick}>기업 비교하기</LargeButton>
+          <LargeButton
+            onClick={handleCompareClick}
+            // myCompany와 compareCompanies가 모두 있어야 활성화
+            disabled={!myCompany && compareCompanies.length === 0}
+            variant={
+              !myCompany || compareCompanies.length === 0
+                ? "inactive"
+                : "active"
+            }
+          >
+            기업 비교하기
+          </LargeButton>
         </div>
       )}
 
       {/* 최종 비교 목록(comparisonList)에 데이터가 있을 때만 비교 테이블들을 렌더링 */}
       {comparisonList.length > 0 ? (
         <>
-          <section className="table-section">
-            <div className="saction-header">
-              <div className="saction-title">비교 결과 확인하기</div>
-              {/* 비교 결과 확인하기 */}
-              <Dropdown
-                value={compareOrder}
-                onChange={setCompareOrder}
-                options={orderOptions}
-              />
-            </div>
-            <div className="grid-table result">
-              <div className="grid-header">
-                <div className="grid-cell">기업명</div>
-                <div className="grid-cell">기업 소개</div>
-                <div className="grid-cell">카테고리</div>
-                <div className="grid-cell">누적 투자 금액</div>
-                <div className="grid-cell">매출액</div>
-                <div className="grid-cell">고용 인원</div>
+          <div className="result-section">
+            <section className="table-section">
+              <div className="saction-header">
+                <div className="saction-title">비교 결과 확인하기</div>
+                {/* 비교 결과 확인하기 */}
+                <Dropdown
+                  value={compareOrder}
+                  onChange={setCompareOrder}
+                  options={orderOptions}
+                />
               </div>
+              
+              <div className="grid-table result">
+                <div className="grid-header">
+                  <div className="grid-cell">기업명</div>
+                  <div className="grid-cell">기업 소개</div>
+                  <div className="grid-cell">카테고리</div>
+                  <div className="grid-cell">누적 투자 금액</div>
+                  <div className="grid-cell">매출액</div>
+                  <div className="grid-cell">고용 인원</div>
+                </div>
 
-              {/* <div className="grid-body"> */}
-              {sortedComparisonList.map((corp, index) => {
-                // 마지막 row border-bottom 없애기 위해 index 추가
-                const isMyCompany = myCompany && myCompany.id === corp.id;
-                const myCompanyRowStyle = isMyCompany ? "myCompany-row" : "";
-                const isLastRow = index === sortedComparisonList.length - 1;
-                const lastRowStyle = isLastRow ? "is-last-row" : "";
-                return (
-                  <div
-                    key={corp.id}
-                    className={`grid-row ${myCompanyRowStyle} ${lastRowStyle}`}
-                  >
-                    <div className="grid-cell company-cell">
-                      <img
-                        src={corp.logoUrl}
-                        alt={`${corp.name} 로고`}
-                        className="corp-logo"
-                      />
-                      <div className="corp-name">{corp.name}</div>
+                {/* <div className="grid-body"> */}
+                {sortedComparisonList.map((corp, index) => {
+                  // 마지막 row border-bottom 없애기 위해 index 추가
+                  const isMyCompany = myCompany && myCompany.id === corp.id;
+                  const myCompanyRowStyle = isMyCompany ? "myCompany-row" : "";
+                  const isLastRow = index === sortedComparisonList.length - 1;
+                  const lastRowStyle = isLastRow ? "is-last-row" : "";
+                  return (
+                    <div
+                      key={corp.id}
+                      className={`grid-row ${myCompanyRowStyle} ${lastRowStyle}`}
+                    >
+                      <div className="grid-cell company-cell">
+                        <img
+                          src={corp.logoUrl}
+                          alt={`${corp.name} 로고`}
+                          className="corp-logo"
+                        />
+                        <div className="corp-name">{corp.name}</div>
+                      </div>
+                      <div className="grid-cell corp-intro">{corp.intro}</div>
+                      <div className="grid-cell">{corp.category}</div>
+                      <div className="grid-cell">{corp.investment}</div>
+                      <div className="grid-cell">{corp.revenue}</div>
+                      <div className="grid-cell">{corp.employees}</div>
                     </div>
-                    <div className="grid-cell">{corp.intro}</div>
-                    <div className="grid-cell">{corp.category}</div>
-                    <div className="grid-cell">{corp.investment}</div>
-                    <div className="grid-cell">{corp.revenue}</div>
-                    <div className="grid-cell">{corp.employees}</div>
-                  </div>
-                );
-              })}
-              {/* </div> */}
-            </div>
-          </section>
-          <section className="table-section">
-            <div className="saction-header">
-              <div className="saction-title">기업 순위 확인하기</div>
-              {/* 기업 순위 확인하기 */}
-              <Dropdown
-                value={rankOrder}
-                onChange={setRankOrder}
-                options={orderOptions}
-              />
-            </div>
-            <div
-              className="grid-table rank"
-              // border="1"
-              // style={{
-              //   borderCollapse: "collapse",
-              //   width: "100%",
-              //   marginTop: 20,
-              // }}
-            >
-              <div className="grid-header">
-                <div className="grid-cell">순위</div>
-                <div className="grid-cell">기업명</div>
-                <div className="grid-cell">기업 소개</div>
-                <div className="grid-cell">카테고리</div>
-                <div className="grid-cell">누적 투자 금액</div>
-                <div className="grid-cell">매출액</div>
-                <div className="grid-cell">고용 인원</div>
+                  );
+                })}
+                {/* </div> */}
               </div>
-              {/* <div className="grid-body"> */}
-              {rankedComparisonList.map((corp, index) => {
-                // 마지막 row border-bottom 없애기 위해 index 추가
-                const isMyCompany = myCompany && myCompany.id === corp.id;
-                const myCompanyRowStyle = isMyCompany ? "myCompany-row" : "";
-                const isLastRow = index === sortedComparisonList.length - 1;
-                const lastRowStyle = isLastRow ? "is-last-row" : "";
-                return (
-                  <div
-                    key={corp.id}
-                    className={`grid-row ${myCompanyRowStyle} ${lastRowStyle}`}
-                  >
-                    <div className="grid-cell">{corp.rank}</div>
-                    <div className="grid-cell company-cell">
-                      <img
-                        src={corp.logoUrl}
-                        alt={`${corp.name} 로고`}
-                        className="corp-logo"
-                      />
-                      <div className="corp-name">{corp.name}</div>
+            </section>
+            <section className="table-section">
+              <div className="saction-header">
+                <div className="saction-title">기업 순위 확인하기</div>
+                {/* 기업 순위 확인하기 */}
+                <Dropdown
+                  value={rankOrder}
+                  onChange={setRankOrder}
+                  options={orderOptions}
+                />
+              </div>
+              <div
+                className="grid-table rank"
+                // border="1"
+                // style={{
+                //   borderCollapse: "collapse",
+                //   width: "100%",
+                //   marginTop: 20,
+                // }}
+              >
+                <div className="grid-header">
+                  <div className="grid-cell">순위</div>
+                  <div className="grid-cell">기업명</div>
+                  <div className="grid-cell">기업 소개</div>
+                  <div className="grid-cell">카테고리</div>
+                  <div className="grid-cell">누적 투자 금액</div>
+                  <div className="grid-cell">매출액</div>
+                  <div className="grid-cell">고용 인원</div>
+                </div>
+                {/* <div className="grid-body"> */}
+                {rankedComparisonList.map((corp, index) => {
+                  // 마지막 row border-bottom 없애기 위해 index 추가
+                  const isMyCompany = myCompany && myCompany.id === corp.id;
+                  const myCompanyRowStyle = isMyCompany ? "myCompany-row" : "";
+                  const isLastRow = index === sortedComparisonList.length - 1;
+                  const lastRowStyle = isLastRow ? "is-last-row" : "";
+                  return (
+                    <div
+                      key={corp.id}
+                      className={`grid-row ${myCompanyRowStyle} ${lastRowStyle}`}
+                    >
+                      <div className="grid-cell">{corp.rank}</div>
+                      <div className="grid-cell company-cell">
+                        <img
+                          src={corp.logoUrl}
+                          alt={`${corp.name} 로고`}
+                          className="corp-logo"
+                        />
+                        <div className="corp-name">{corp.name}</div>
+                      </div>
+                      <div className="grid-cell corp-intro">{corp.intro}</div>
+                      {/* FIXME: 기업 소개도 두줄까지만 허용하고 ellipsis */}
+                      <div className="grid-cell">{corp.category}</div>
+                      <div className="grid-cell">{corp.investment}</div>
+                      <div className="grid-cell">{corp.revenue}</div>
+                      <div className="grid-cell">{corp.employees}</div>
                     </div>
-                    <div className="grid-cell">{corp.intro}</div>
-                    {/* FIXME: 기업 소개도 두줄까지만 허용하고 ellipsis */}
-                    <div className="grid-cell">{corp.category}</div>
-                    <div className="grid-cell">{corp.investment}</div>
-                    <div className="grid-cell">{corp.revenue}</div>
-                    <div className="grid-cell">{corp.employees}</div>
-                  </div>
-                );
-              })}
-            </div>
-          </section>
+                  );
+                })}
+              </div>
+            </section>
+          </div>
           {/* </div> */}
           <div className="btn-center">
             <LargeButton onClick={() => setIsModalOpen(true)}>
@@ -308,6 +382,7 @@ export default function ComparePage() {
           isOpen={isModalOpen}
           company={myCompany} // 기업 정보 객체를 통째로 전달
           onClose={() => setIsModalOpen(false)}
+          // initialData가 없으므로 '생성' 모드로 동작
         />
       )}
     </div>


### PR DESCRIPTION
## 작업 내용
- Card Container 카드 제거 기능 구현
  - 내 기업 카드 제거시 비교 기업 카드 제거
  - 비교 기업 카드 제거시 해당 기업 카드만 제거
- api 연동을 위한 axios 인스턴스 및 모듈 구조 세팅
- 조건부 렌더링
  - Card Container 버튼
    - 내 기업 카드 있을 때만 기업 변경하기 버튼 appear
  - 비교하기 버튼
    - 클릭 시 disappear (대신 표 appear)
    - 내 기업, 비교 기업 카드 변경 사항 있으면 appear, active
      - 대신 내 기업 카드 변경시 disabled, inactive
- 투자하기 모달 완료 후 alert 모달 구현
  -  api 호출 로직도 추가. 아직 기능XX

## 테스트 방법
제가 목 api연동한 채로 PR했어야했는데 현재 연동중인 API로 PR해서 확인이 어렵습니다ㅠ 얼른 연동해서 다시 PR 날리겠습니다!

## 참고 사진
사진 캡처하지 않은 채 현재 API 연동 중입니다ㅠㅠ API 연동 후 다음 PR에서 제출하겠습니다!

## 추후 구현
- 기업 컨테이너 버튼 disabled, active 및 텍스트 조건부 렌더링 구현
- api 연동 및 테스트